### PR TITLE
feat: Integrate fuzzy finder for /add and /read-only commands

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1386,22 +1386,36 @@ class Commands:
             self.io.tool_error(f"Error processing clipboard content: {e}")
 
     def cmd_read_only(self, args):
-        "Add files to the chat that are for reference only, or turn added files to read-only"
+        (
+            "Add files to the chat that are for reference only, or turn added files to read-only.\n"
+            "With no args, opens a fuzzy finder to select files from the repo.\n"
+            "If no files are selected, converts all editable files in chat to read-only."
+        )
         if not args.strip():
             all_files = self.coder.get_all_relative_files()
-            if not all_files:
-                self.io.tool_output("No files available to add.")
+            if self.coder.repo:
+                all_files = self.coder.repo.get_tracked_files()
+
+            if not all_files and not self.coder.abs_fnames:
+                self.io.tool_output("No files in the repo or chat to make read-only.")
                 return
-            selected_files = run_fzf(all_files, multi=True)
+
+            selected_files = []
+            if all_files:
+                selected_files = run_fzf(all_files, multi=True)
+
             if not selected_files:
-                # Convert all files in chat to read-only
+                # Fallback behavior: convert all editable files to read-only
                 if self.coder.abs_fnames:
                     for fname in list(self.coder.abs_fnames):
                         self.coder.abs_fnames.remove(fname)
                         self.coder.abs_read_only_fnames.add(fname)
                         rel_fname = self.coder.get_rel_fname(fname)
                         self.io.tool_output(f"Converted {rel_fname} to read-only")
+                else:
+                    self.io.tool_output("No files selected.")
                 return
+
             args = " ".join([self.quote_fname(f) for f in selected_files])
 
         filenames = parse_quoted_filenames(args)

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -24,7 +24,7 @@ from aider.llm import litellm
 from aider.repo import ANY_GIT_ERROR
 from aider.run_cmd import run_cmd
 from aider.scrape import Scraper, install_playwright
-from aider.utils import is_image_file
+from aider.utils import is_image_file, run_fzf
 from .dump import dump  # noqa: F401
 
 
@@ -830,6 +830,18 @@ class Commands:
     def cmd_add(self, args):
         "Add files to the chat so aider can edit them or review them in detail"
 
+        if not args.strip():
+            all_files = self.coder.get_all_relative_files()
+            files_in_chat = self.coder.get_inchat_relative_files()
+            addable_files = sorted(list(set(all_files) - set(files_in_chat)))
+            if not addable_files:
+                self.io.tool_output("No files available to add.")
+                return
+            selected_files = run_fzf(addable_files, multi=True)
+            if not selected_files:
+                return
+            args = " ".join([self.quote_fname(f) for f in selected_files])
+
         all_matched_files = set()
 
         filenames = parse_quoted_filenames(args)
@@ -1376,13 +1388,21 @@ class Commands:
     def cmd_read_only(self, args):
         "Add files to the chat that are for reference only, or turn added files to read-only"
         if not args.strip():
-            # Convert all files in chat to read-only
-            for fname in list(self.coder.abs_fnames):
-                self.coder.abs_fnames.remove(fname)
-                self.coder.abs_read_only_fnames.add(fname)
-                rel_fname = self.coder.get_rel_fname(fname)
-                self.io.tool_output(f"Converted {rel_fname} to read-only")
-            return
+            all_files = self.coder.get_all_relative_files()
+            if not all_files:
+                self.io.tool_output("No files available to add.")
+                return
+            selected_files = run_fzf(all_files, multi=True)
+            if not selected_files:
+                # Convert all files in chat to read-only
+                if self.coder.abs_fnames:
+                    for fname in list(self.coder.abs_fnames):
+                        self.coder.abs_fnames.remove(fname)
+                        self.coder.abs_read_only_fnames.add(fname)
+                        rel_fname = self.coder.get_rel_fname(fname)
+                        self.io.tool_output(f"Converted {rel_fname} to read-only")
+                return
+            args = " ".join([self.quote_fname(f) for f in selected_files])
 
         filenames = parse_quoted_filenames(args)
         all_paths = []
@@ -1636,6 +1656,13 @@ class Commands:
     def cmd_edit(self, args=""):
         "Alias for /editor: Open an editor to write a prompt"
         return self.cmd_editor(args)
+
+    def cmd_history_search(self, args):
+        "Fuzzy search in history and paste it in the prompt"
+        history_lines = self.io.get_input_history()
+        selected_lines = run_fzf(history_lines)
+        if selected_lines:
+            self.io.set_placeholder("".join(selected_lines))
 
     def cmd_think_tokens(self, args):
         """Set the thinking token budget, eg: 8096, 8k, 10.5k, 0.5M, or 0 to disable."""

--- a/aider/io.py
+++ b/aider/io.py
@@ -37,7 +37,7 @@ from aider.mdstream import MarkdownStream
 
 from .dump import dump  # noqa: F401
 from .editor import pipe_editor
-from .utils import is_image_file
+from .utils import is_image_file, run_fzf
 
 # Constants
 NOTIFICATION_MESSAGE = "Aider is waiting for your input"
@@ -295,6 +295,13 @@ class InputOutput:
         self.completion_menu_current_bg_color = (
             ensure_hash_prefix(completion_menu_current_bg_color) if pretty else None
         )
+
+        self.fzf_available = shutil.which("fzf")
+        if not self.fzf_available:
+            self.tool_warning(
+                "fzf not found, fuzzy finder features will be disabled. Install it for enhanced"
+                " file/history search."
+            )
 
         self.code_theme = code_theme
 
@@ -608,6 +615,28 @@ class InputOutput:
 
             # Move cursor to the end of the text
             buffer.cursor_position = len(buffer.text)
+
+        @kb.add("c-t", filter=Condition(lambda: self.fzf_available))
+        def _(event):
+            "Fuzzy find files to add to the chat"
+            buffer = event.current_buffer
+            if not buffer.text.strip().startswith("/add "):
+                return
+
+            files = run_fzf(addable_rel_fnames, multi=True)
+            if files:
+                buffer.text = "/add " + " ".join(files)
+                buffer.cursor_position = len(buffer.text)
+
+        @kb.add("c-r", filter=Condition(lambda: self.fzf_available))
+        def _(event):
+            "Fuzzy search in history and paste it in the prompt"
+            buffer = event.current_buffer
+            history_lines = self.get_input_history()
+            selected_lines = run_fzf(history_lines)
+            if selected_lines:
+                buffer.text = "".join(selected_lines)
+                buffer.cursor_position = len(buffer.text)
 
         @kb.add("enter", eager=True, filter=~is_searching)
         def _(event):

--- a/aider/io.py
+++ b/aider/io.py
@@ -264,6 +264,13 @@ class InputOutput:
         notifications=False,
         notifications_command=None,
     ):
+        self.console = Console()
+        self.pretty = pretty
+        if chat_history_file is not None:
+            self.chat_history_file = Path(chat_history_file)
+        else:
+            self.chat_history_file = None
+
         self.placeholder = None
         self.interrupted = False
         self.never_prompts = set()

--- a/aider/utils.py
+++ b/aider/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+import shutil
 
 import oslex
 
@@ -11,6 +12,38 @@ from aider.dump import dump  # noqa: F401
 from aider.waiting import Spinner
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp", ".pdf"}
+
+
+def run_fzf(input_data, multi=False):
+    """
+    Runs fzf as a subprocess, feeding it input_data.
+    Returns the selected items.
+    """
+    if not shutil.which("fzf"):
+        return None  # Or raise an exception
+
+    fzf_command = ["fzf"]
+    if multi:
+        fzf_command.append("--multi")
+
+    # Recommended flags for a good experience
+    fzf_command.extend(["--height", "80%", "--reverse"])
+
+    process = subprocess.Popen(
+        fzf_command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    # fzf expects a newline-separated list of strings
+    stdout, _ = process.communicate("\n".join(input_data))
+
+    if process.returncode == 0:
+        # fzf returns selected items newline-separated
+        return stdout.strip().split("\n")
+    else:
+        # User cancelled (e.g., pressed Esc)
+        return []
 
 
 class IgnorantTemporaryDirectory:


### PR DESCRIPTION
This update enhances the `/add` and `/read-only` commands by integrating a fuzzy finder, making it easier to add files to the chat.

Previously, adding files required typing out their full paths or using glob patterns. Now, you can simply run `/add` or `/read-only` without any arguments to open an interactive fuzzy finder (`fzf`). This allows you to quickly search for and select one or more files from your repository to add to the chat.

For the `/read-only` command, the original functionality is preserved as a convenient fallback. If you open the fuzzy finder and close it (ctrl+c) without selecting any files, the command will automatically convert all currently editable files in the chat to read-only.

**Usage:**

* **To add files for editing:**
  ```
  /add
  ```
  This will open a fuzzy finder to select files.

* **To add files as read-only:**
  ```
  /read-only
  ```
  This will open a fuzzy finder. If you select files, they will be added as read-only. If you close the finder (ctrl+c) without making a selection, all editable files in the chat will be converted to read-only (preserved existing behavior).

This change makes the process of adding files, improving the overall user experience.

Note: If fzf is not installed, the fuzzy finder features are gracefully disabled, and the commands fall back to their original behavior.